### PR TITLE
chore(output): disable tag on user select

### DIFF
--- a/src/components/Output.vue
+++ b/src/components/Output.vue
@@ -56,6 +56,10 @@ export default {
         padding: 0 4px;
         background-color: rgba(139, 195, 74, 0.1);
         color: #8bc34a;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
       }
     }
 
@@ -76,7 +80,7 @@ export default {
   <div class="containerBot">
     <h2>Output</h2>
     <select @change="onChangeSelect" class="type" v-model="selectedType">
-      <option v-for="t in types" v-bind:value="t.value" v-bind:key="t.text">{{ t.text }}</option>
+      <option v-for="(t, index) in types" v-bind:value="index" v-bind:key="t">{{ t }}</option>
     </select>
     <div class="content" v-html="value" />
   </div>

--- a/src/lib/conversionOrder.js
+++ b/src/lib/conversionOrder.js
@@ -1,0 +1,1 @@
+export default ["Account", "Reverse Hex", "Fixed8", "Fixed8 -> Num"];

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,6 +3,7 @@ import Vuex from "vuex";
 import tree from "switch-tree";
 
 import * as conversions from "./../lib/conversions";
+import conversionOrder from "./../lib/conversionOrder";
 
 Vue.use(Vuex);
 
@@ -10,14 +11,9 @@ export default new Vuex.Store({
   state: {
     inputValue: "",
     inputType: "",
-    outputValue: "",
-    outputType: "0",
-    outputTypes: [
-      { text: "Reverse Hex", value: "0" },
-      { text: "Account", value: "1" },
-      { text: "Fixed8", value: "2" },
-      { text: "Fixed8 > Num", value: "3" }
-    ]
+    outputValue: conversions.account(),
+    outputType: 0,
+    outputTypes: conversionOrder
   },
   getters: {
     getInputValue(state) {
@@ -49,14 +45,14 @@ export default new Vuex.Store({
   },
   actions: {
     convert({ commit, state }) {
-      const outputType = parseInt(state.outputType, 10);
+      const outputType = conversionOrder[parseInt(state.outputType, 10)];
 
       const execute = tree`
         lazy ${outputType}
-          value ${0} ${conversions.reverseHex}
-          value ${1} ${conversions.account}
-          value ${2} ${conversions.int2fixed8}
-          value ${3} ${conversions.fixed82int}
+          value ${"Reverse Hex"} ${conversions.reverseHex}
+          value ${"Account"} ${conversions.account}
+          value ${"Fixed8"} ${conversions.int2fixed8}
+          value ${"Fixed8 -> Num"} ${conversions.fixed82int}
       `;
 
       commit("setOutputValue", execute(state.inputValue));


### PR DESCRIPTION
Disables the tags when selecting an account value.

For example: you select the scriptHash, you don't want the string value `scriptHash` to be selected too.