### PR TITLE
feat(conversions): convert scriptHash to Python/C#

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@cityofzion/neon-js": "^3.5.0",
+    "bsqsq": "^1.0.1",
     "debounce": "^1.1.0",
     "register-service-worker": "^1.0.0",
     "switch-tree": "^0.1.0",

--- a/src/lib/converToCSharp.js
+++ b/src/lib/converToCSharp.js
@@ -1,0 +1,15 @@
+import { u, wallet } from "@cityofzion/neon-js";
+
+const printAddress = u8a => {
+  let result = "{ ";
+  u8a.forEach((x, index) => {
+    result += index !== u8a.length - 1 ? `${x}, ` : `${x} }`;
+  });
+  return result;
+};
+
+export default addressOrHash => {
+  const account = new wallet.Account(addressOrHash);
+  const u8Array = u.reverseArray(u.hexstring2ab(account.scriptHash));
+  return printAddress(u8Array);
+};

--- a/src/lib/conversions.js
+++ b/src/lib/conversions.js
@@ -1,14 +1,22 @@
 import { u, wallet } from "@cityofzion/neon-js";
+import bsqsq from "bsqsq";
+
+import convertToCSharp from "./../lib/converToCSharp";
 
 export const account = input => {
   let output = "";
   try {
     const acct = new wallet.Account(input);
+    const python = bsqsq(acct.scriptHash, true);
+    const cSharp = convertToCSharp(acct.scriptHash);
+
     output += `<p class="tag">Address</p><p>${acct.address}</p><br />`;
     output += `<p class="tag">Scripthash</p><p>${acct.scriptHash}</p><br />`;
+    output += `<p class="tag">Python Account</p><p>${python}</p><br />`;
+    output += `<p class="tag">C# Account</p><p>${cSharp}</p><br />`;
     output += `<p class="tag">Public Key</p><p>${acct.publicKey}</p><br />`;
-    output += `<p class="tag">Private Key</p><p>${acct.privateKey}</p><br />`;
     output += `<p class="tag">WIF</p><p>${acct.WIF}</p><br />`;
+    output += `<p class="tag">Private Key</p><p>${acct.privateKey}</p><br />`;
     return output;
   } catch (err) {
     return output !== "" ? output : "Invalid Input!";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,10 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+bsqsq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bsqsq/-/bsqsq-1.0.1.tgz#66d3aaa4eb3681668493437cd59825fff00ab2b4"
+
 buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"


### PR DESCRIPTION
Automatically reverseHex and converts the scriptHash to Python and C# bytearrays for smart contract/debugging usage